### PR TITLE
Enable log delivery to CloudWatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_bedrockagent_data_source.knowledge_base_ds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_data_source) | resource |
+| [aws_cloudwatch_log_group.knowledge_base_cwl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.bedrock_knowledge_base_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agent_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.bedrock_knowledge_base_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -129,6 +130,9 @@ No modules.
 | [awscc_bedrock_knowledge_base.knowledge_base_opensearch](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/bedrock_knowledge_base) | resource |
 | [awscc_bedrock_knowledge_base.knowledge_base_pinecone](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/bedrock_knowledge_base) | resource |
 | [awscc_bedrock_knowledge_base.knowledge_base_rds](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/bedrock_knowledge_base) | resource |
+| [awscc_logs_delivery.knowledge_base_log_delivery](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/logs_delivery) | resource |
+| [awscc_logs_delivery_destination.knowledge_base_log_destination](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/logs_delivery_destination) | resource |
+| [awscc_logs_delivery_source.knowledge_base_log_source](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/logs_delivery_source) | resource |
 | [awscc_opensearchserverless_collection.default_collection](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/opensearchserverless_collection) | resource |
 | [awscc_s3_bucket.s3_data_source](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/s3_bucket) | resource |
 | [opensearch_index.default_oss_index](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/index) | resource |
@@ -163,6 +167,7 @@ No modules.
 | <a name="input_create_agent"></a> [create\_agent](#input\_create\_agent) | Whether or not to deploy an agent. | `bool` | `true` | no |
 | <a name="input_create_default_kb"></a> [create\_default\_kb](#input\_create\_default\_kb) | Whether or not to create the default knowledge base. | `bool` | `false` | no |
 | <a name="input_create_kb"></a> [create\_kb](#input\_create\_kb) | Whether or not to attach a knowledge base. | `bool` | `false` | no |
+| <a name="input_create_kb_log_group"></a> [create\_kb\_log\_group](#input\_create\_kb\_log\_group) | Whether or not to create a log group for the knowledge base. | `bool` | `false` | no |
 | <a name="input_create_mongo_config"></a> [create\_mongo\_config](#input\_create\_mongo\_config) | Whether or not to use MongoDB Atlas configuration | `bool` | `false` | no |
 | <a name="input_create_opensearch_config"></a> [create\_opensearch\_config](#input\_create\_opensearch\_config) | Whether or not to use Opensearch Serverless configuration | `bool` | `false` | no |
 | <a name="input_create_pinecone_config"></a> [create\_pinecone\_config](#input\_create\_pinecone\_config) | Whether or not to use Pinecone configuration | `bool` | `false` | no |
@@ -181,6 +186,8 @@ No modules.
 | <a name="input_idle_session_ttl"></a> [idle\_session\_ttl](#input\_idle\_session\_ttl) | How long sessions should be kept open for the agent. | `number` | `600` | no |
 | <a name="input_kb_description"></a> [kb\_description](#input\_kb\_description) | Description of knowledge base. | `string` | `"Terraform deployed Knowledge Base"` | no |
 | <a name="input_kb_embedding_model_arn"></a> [kb\_embedding\_model\_arn](#input\_kb\_embedding\_model\_arn) | The ARN of the model used to create vector embeddings for the knowledge base. | `string` | `"arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"` | no |
+| <a name="input_kb_log_group_retention_in_days"></a> [kb\_log\_group\_retention\_in\_days](#input\_kb\_log\_group\_retention\_in\_days) | The retention period of the knowledge base log group. | `number` | `0` | no |
+| <a name="input_kb_monitoring_arn"></a> [kb\_monitoring\_arn](#input\_kb\_monitoring\_arn) | The ARN of the target for delivery of knowledge base application logs | `string` | `null` | no |
 | <a name="input_kb_name"></a> [kb\_name](#input\_kb\_name) | Name of the knowledge base. | `string` | `"knowledge-base"` | no |
 | <a name="input_kb_role_arn"></a> [kb\_role\_arn](#input\_kb\_role\_arn) | The ARN of the IAM role with permission to invoke API operations on the knowledge base. | `string` | `null` | no |
 | <a name="input_kb_s3_data_source"></a> [kb\_s3\_data\_source](#input\_kb\_s3\_data\_source) | The S3 data source ARN for the knowledge base. | `string` | `null` | no |
@@ -218,5 +225,12 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#output\_cloudwatch\_log\_group) | The name of the CloudWatch log group for the knowledge base.  If no log group was requested, value will be null |
+| <a name="output_datasource_identifier"></a> [datasource\_identifier](#output\_datasource\_identifier) | The unique identifier of the data source. |
 | <a name="output_default_collection"></a> [default\_collection](#output\_default\_collection) | Opensearch default collection value. |
+| <a name="output_default_kb_identifier"></a> [default\_kb\_identifier](#output\_default\_kb\_identifier) | The unique identifier of the default knowledge base that was created.  If no default KB was requested, value will be null |
+| <a name="output_mongo_kb_identifier"></a> [mongo\_kb\_identifier](#output\_mongo\_kb\_identifier) | The unique identifier of the MongoDB knowledge base that was created.  If no MongoDB KB was requested, value will be null |
+| <a name="output_opensearch_kb_identifier"></a> [opensearch\_kb\_identifier](#output\_opensearch\_kb\_identifier) | The unique identifier of the OpenSearch knowledge base that was created.  If no OpenSearch KB was requested, value will be null |
+| <a name="output_pinecone_kb_identifier"></a> [pinecone\_kb\_identifier](#output\_pinecone\_kb\_identifier) | The unique identifier of the Pinecone knowledge base that was created.  If no Pinecone KB was requested, value will be null |
+| <a name="output_rds_kb_identifier"></a> [rds\_kb\_identifier](#output\_rds\_kb\_identifier) | The unique identifier of the RDS knowledge base that was created.  If no RDS KB was requested, value will be null |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,39 @@
 output "default_collection" {
-  value =  awscc_opensearchserverless_collection.default_collection
+  value       = awscc_opensearchserverless_collection.default_collection
   description = "Opensearch default collection value."
+}
+
+output "default_kb_identifier" {
+  value       = length(awscc_bedrock_knowledge_base.knowledge_base_default) > 0 ? awscc_bedrock_knowledge_base.knowledge_base_default[0].id : null
+  description = "The unique identifier of the default knowledge base that was created.  If no default KB was requested, value will be null"
+}
+
+output "mongo_kb_identifier" {
+  value       = length(awscc_bedrock_knowledge_base.knowledge_base_mongo) > 0 ? awscc_bedrock_knowledge_base.knowledge_base_mongo[0].id : null
+  description = "The unique identifier of the MongoDB knowledge base that was created.  If no MongoDB KB was requested, value will be null"
+}
+
+output "opensearch_kb_identifier" {
+  value       = length(awscc_bedrock_knowledge_base.knowledge_base_opensearch) > 0 ? awscc_bedrock_knowledge_base.knowledge_base_opensearch[0].id : null
+  description = "The unique identifier of the OpenSearch knowledge base that was created.  If no OpenSearch KB was requested, value will be null"
+}
+
+output "pinecone_kb_identifier" {
+  value       = length(awscc_bedrock_knowledge_base.knowledge_base_pinecone) > 0 ? awscc_bedrock_knowledge_base.knowledge_base_pinecone[0].id : null
+  description = "The unique identifier of the Pinecone knowledge base that was created.  If no Pinecone KB was requested, value will be null"
+}
+
+output "rds_kb_identifier" {
+  value       = length(awscc_bedrock_knowledge_base.knowledge_base_rds) > 0 ? awscc_bedrock_knowledge_base.knowledge_base_rds[0].id : null
+  description = "The unique identifier of the RDS knowledge base that was created.  If no RDS KB was requested, value will be null"
+}
+
+output "datasource_identifier" {
+  value       = length(aws_bedrockagent_data_source.knowledge_base_ds) > 0 ? aws_bedrockagent_data_source.knowledge_base_ds[0].data_source_id : null
+  description = "The unique identifier of the data source."
+}
+
+output "cloudwatch_log_group" {
+  value       = length(aws_cloudwatch_log_group.knowledge_base_cwl) > 0 ? aws_cloudwatch_log_group.knowledge_base_cwl[0].name : null
+  description = "The name of the CloudWatch log group for the knowledge base.  If no log group was requested, value will be null"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -121,7 +121,7 @@ variable "override_lambda_arn" {
   default     = null
 }
 
-# – Inference Configuration – 
+# – Inference Configuration –
 
 variable "temperature" {
   description = "The likelihood of the model selecting higher-probability options while generating a response."
@@ -311,7 +311,29 @@ variable "endpoint" {
   default     = null
 }
 
-# – MongoDB Atlas Configuration – 
+variable "kb_monitoring_arn" {
+  description = "The ARN of the target for delivery of knowledge base application logs"
+  type        = string
+  default     = null
+}
+
+variable "create_kb_log_group" {
+  description = "Whether or not to create a log group for the knowledge base."
+  type        = bool
+  default     = false
+}
+
+variable "kb_log_group_retention_in_days" {
+  description = "The retention period of the knowledge base log group."
+  type        = number
+  default     = 0
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, 0], var.kb_log_group_retention_in_days)
+    error_message = "The provided retention period is not a valid CloudWatch logs retention period"
+  }
+}
+
+# – MongoDB Atlas Configuration –
 
 variable "create_mongo_config" {
   description = "Whether or not to use MongoDB Atlas configuration"
@@ -327,7 +349,7 @@ variable "endpoint_service_name" {
 
 
 # – Opensearch Serverless Configuration –
-# the default vector database 
+# the default vector database
 
 variable "create_opensearch_config" {
   description = "Whether or not to use Opensearch Serverless configuration"
@@ -335,7 +357,7 @@ variable "create_opensearch_config" {
   default     = false
 }
 
-# – Pinecone Configuration – 
+# – Pinecone Configuration –
 
 variable "create_pinecone_config" {
   description = "Whether or not to use Pinecone configuration"
@@ -355,7 +377,7 @@ variable "namespace" {
   default     = null
 }
 
-# – RDS Configuration – 
+# – RDS Configuration –
 
 variable "create_rds_config" {
   description = "Whether or not to use RDS configuration"
@@ -419,7 +441,7 @@ variable "skip_resource_in_use" {
   default     = null
 }
 
-# – Action Group Executor – 
+# – Action Group Executor –
 
 variable "custom_control" {
   description = "Custom control of action execution."


### PR DESCRIPTION
This PR adds a new option to create a CloudWatch log group and configure delivery.  Users may also provide a log destination as an ARN.  CloudWatch log group name is configured as an output to enable later creation of a metric filter, something that is out of scope for this module.  Additional outputs were "nice to haves" while I was in the `outputs.tf` file.

Implementation follows [official documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-bases-logging.html) for monitoring Bedrock.