### PR TITLE
S3 encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_bedrockagent_data_source.knowledge_base_ds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_data_source) | resource |
+| [aws_iam_policy.bedrock_kb_s3_decryption_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.bedrock_knowledge_base_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agent_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.bedrock_knowledge_base_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.agent_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.bedrock_kb_oss](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.kb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.bedrock_kb_s3_decryption_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.bedrock_knowledge_base_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_opensearchserverless_access_policy.data_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_access_policy) | resource |
 | [aws_opensearchserverless_security_policy.nw_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy) | resource |
@@ -184,6 +186,7 @@ No modules.
 | <a name="input_kb_name"></a> [kb\_name](#input\_kb\_name) | Name of the knowledge base. | `string` | `"knowledge-base"` | no |
 | <a name="input_kb_role_arn"></a> [kb\_role\_arn](#input\_kb\_role\_arn) | The ARN of the IAM role with permission to invoke API operations on the knowledge base. | `string` | `null` | no |
 | <a name="input_kb_s3_data_source"></a> [kb\_s3\_data\_source](#input\_kb\_s3\_data\_source) | The S3 data source ARN for the knowledge base. | `string` | `null` | no |
+| <a name="input_kb_s3_data_source_kms_arn"></a> [kb\_s3\_data\_source\_kms\_arn](#input\_kb\_s3\_data\_source\_kms\_arn) | The ARN of the KMS key used to encrypt S3 content | `string` | `null` | no |
 | <a name="input_kb_state"></a> [kb\_state](#input\_kb\_state) | State of knowledge base; whether it is enabled or disabled | `string` | `"ENABLED"` | no |
 | <a name="input_kb_storage_type"></a> [kb\_storage\_type](#input\_kb\_storage\_type) | The storage type of a knowledge base. | `string` | `null` | no |
 | <a name="input_kb_tags"></a> [kb\_tags](#input\_kb\_tags) | A map of tags keys and values for the knowledge base. | `map(string)` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_bedrockagent_data_source.knowledge_base_ds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_data_source) | resource |
-| [aws_iam_policy.bedrock_kb_s3_decryption_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_cloudwatch_log_group.knowledge_base_cwl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.bedrock_kb_s3_decryption_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.bedrock_knowledge_base_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agent_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.bedrock_knowledge_base_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -234,7 +234,7 @@ No modules.
 | <a name="input_text_field"></a> [text\_field](#input\_text\_field) | The name of the field in which Amazon Bedrock stores the raw text from your data. | `string` | `"AMAZON_BEDROCK_TEXT_CHUNK"` | no |
 | <a name="input_top_k"></a> [top\_k](#input\_top\_k) | Sample from the k most likely next tokens. | `number` | `50` | no |
 | <a name="input_top_p"></a> [top\_p](#input\_top\_p) | Cumulative probability cutoff for token selection. | `number` | `0.5` | no |
-| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list( object({<br>                  name       = string<br>                  examples   = list(string)<br>                  type       = string<br>                  definition = string<br>                }))</pre> | `null` | no |
+| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list( object({<br/>                  name       = string<br/>                  examples   = list(string)<br/>                  type       = string<br/>                  definition = string<br/>                }))</pre> | `null` | no |
 | <a name="input_vector_field"></a> [vector\_field](#input\_vector\_field) | The name of the field where the vector embeddings are stored | `string` | `"bedrock-knowledge-base-default-vector"` | no |
 | <a name="input_vector_index_name"></a> [vector\_index\_name](#input\_vector\_index\_name) | The name of the vector index. | `string` | `"bedrock-knowledge-base-default-index"` | no |
 | <a name="input_words_config"></a> [words\_config](#input\_words\_config) | List of custom word configs. | `list(map(string))` | `null` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,7 @@
-# – IAM – 
+# – IAM –
+locals {
+  create_kb_role = var.kb_role_arn == null && var.create_default_kb
+}
 
 resource "aws_iam_role" "agent_role" {
   count              = var.create_agent ? 1 : 0
@@ -64,7 +67,7 @@ resource "aws_iam_policy" "bedrock_knowledge_base_policy" {
         "Action" : [
           "aoss:*"
         ],
-        "Resource" : awscc_opensearchserverless_collection.default_collection[0].arn 
+        "Resource" : awscc_opensearchserverless_collection.default_collection[0].arn
       },
       {
         "Effect" : "Allow",
@@ -85,11 +88,38 @@ resource "aws_iam_policy" "bedrock_knowledge_base_policy" {
   })
 }
 
-# Attach the policy to the role
+resource "aws_iam_policy" "bedrock_kb_s3_decryption_policy" {
+  count = local.create_kb_role && var.kb_s3_data_source_kms_arn != null ? 1 : 0
+  name = "AmazonBedrockS3KMSPolicyForKnowledgeBase_${random_string.solution_prefix.result}"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "kms:Decrypt",
+        "Resource" : var.kb_s3_data_source_kms_arn
+        "Condition": {
+          "StringEquals": {
+            "kms:ViaService": ["s3.${data.aws_region.current.name}.amazonaws.com"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Attach the policies to the role
 resource "aws_iam_role_policy_attachment" "bedrock_knowledge_base_policy_attachment" {
   count      = var.kb_role_arn != null || var.create_kb == false ? 0 : 1
   role       = aws_iam_role.bedrock_knowledge_base_role[0].name
   policy_arn = aws_iam_policy.bedrock_knowledge_base_policy[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock_kb_s3_decryption_policy_attachment" {
+  count      = local.create_kb_role && var.kb_s3_data_source_kms_arn != null ? 1 : 0
+  role       = aws_iam_role.bedrock_knowledge_base_role[0].name
+  policy_arn = aws_iam_policy.bedrock_kb_s3_decryption_policy[0].arn
 }
 
 resource "aws_iam_role_policy" "bedrock_kb_oss" {

--- a/knowledge-base.tf
+++ b/knowledge-base.tf
@@ -153,6 +153,23 @@ resource "awscc_s3_bucket" "s3_data_source" {
   count       = var.kb_s3_data_source == null && var.create_default_kb == true ? 1 : 0
   bucket_name = "${random_string.solution_prefix.result}-${var.kb_name}-default-bucket"
 
+  public_access_block_configuration = {
+    block_public_acls       = true
+    block_public_policy     = true
+    ignore_public_acls      = true
+    restrict_public_buckets = true
+  }
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [{
+      bucket_key_enabled = true
+      server_side_encryption_by_default = {
+        sse_algorithm     = var.kb_s3_data_source_kms_arn == null ? "AES256" : "aws:kms"
+        kms_master_key_id = var.kb_s3_data_source_kms_arn
+      }
+    }]
+  }
+
   tags = [{
     key   = "Name"
     value = "S3 Data Source"

--- a/variables.tf
+++ b/variables.tf
@@ -121,7 +121,7 @@ variable "override_lambda_arn" {
   default     = null
 }
 
-# – Inference Configuration – 
+# – Inference Configuration –
 
 variable "temperature" {
   description = "The likelihood of the model selecting higher-probability options while generating a response."
@@ -200,6 +200,12 @@ variable "create_default_kb" {
 
 variable "kb_s3_data_source" {
   description = "The S3 data source ARN for the knowledge base."
+  type        = string
+  default     = null
+}
+
+variable "kb_s3_data_source_kms_arn" {
+  description = "The ARN of the KMS key used to encrypt S3 content"
   type        = string
   default     = null
 }
@@ -311,7 +317,7 @@ variable "endpoint" {
   default     = null
 }
 
-# – MongoDB Atlas Configuration – 
+# – MongoDB Atlas Configuration –
 
 variable "create_mongo_config" {
   description = "Whether or not to use MongoDB Atlas configuration"
@@ -327,7 +333,7 @@ variable "endpoint_service_name" {
 
 
 # – Opensearch Serverless Configuration –
-# the default vector database 
+# the default vector database
 
 variable "create_opensearch_config" {
   description = "Whether or not to use Opensearch Serverless configuration"
@@ -335,7 +341,7 @@ variable "create_opensearch_config" {
   default     = false
 }
 
-# – Pinecone Configuration – 
+# – Pinecone Configuration –
 
 variable "create_pinecone_config" {
   description = "Whether or not to use Pinecone configuration"
@@ -355,7 +361,7 @@ variable "namespace" {
   default     = null
 }
 
-# – RDS Configuration – 
+# – RDS Configuration –
 
 variable "create_rds_config" {
   description = "Whether or not to use RDS configuration"
@@ -419,7 +425,7 @@ variable "skip_resource_in_use" {
   default     = null
 }
 
-# – Action Group Executor – 
+# – Action Group Executor –
 
 variable "custom_control" {
   description = "Custom control of action execution."


### PR DESCRIPTION
This PR allows users to provide a KMS key to encrypt data at rest in S3.  More importantly, the IAM role for the KB is granted decrypt access to the key for the purposes of ingesting content.  The IAM permissions present in this PR match the specific policy generated by the AWS Console wizard for KB creation.