### PR TITLE
Allow user to provide a KMS key to encrypt S3 content

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ No modules.
 |------|------|
 | [aws_bedrockagent_data_source.knowledge_base_ds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_data_source) | resource |
 | [aws_cloudwatch_log_group.knowledge_base_cwl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.bedrock_kb_s3_decryption_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.bedrock_knowledge_base_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agent_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.bedrock_knowledge_base_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.agent_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.bedrock_kb_oss](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.kb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.bedrock_kb_s3_decryption_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.bedrock_knowledge_base_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_opensearchserverless_access_policy.data_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_access_policy) | resource |
 | [aws_opensearchserverless_security_policy.nw_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearchserverless_security_policy) | resource |
@@ -201,6 +203,7 @@ No modules.
 | <a name="input_kb_name"></a> [kb\_name](#input\_kb\_name) | Name of the knowledge base. | `string` | `"knowledge-base"` | no |
 | <a name="input_kb_role_arn"></a> [kb\_role\_arn](#input\_kb\_role\_arn) | The ARN of the IAM role with permission to invoke API operations on the knowledge base. | `string` | `null` | no |
 | <a name="input_kb_s3_data_source"></a> [kb\_s3\_data\_source](#input\_kb\_s3\_data\_source) | The S3 data source ARN for the knowledge base. | `string` | `null` | no |
+| <a name="input_kb_s3_data_source_kms_arn"></a> [kb\_s3\_data\_source\_kms\_arn](#input\_kb\_s3\_data\_source\_kms\_arn) | The ARN of the KMS key used to encrypt S3 content | `string` | `null` | no |
 | <a name="input_kb_state"></a> [kb\_state](#input\_kb\_state) | State of knowledge base; whether it is enabled or disabled | `string` | `"ENABLED"` | no |
 | <a name="input_kb_storage_type"></a> [kb\_storage\_type](#input\_kb\_storage\_type) | The storage type of a knowledge base. | `string` | `null` | no |
 | <a name="input_kb_tags"></a> [kb\_tags](#input\_kb\_tags) | A map of tags keys and values for the knowledge base. | `map(string)` | `null` | no |
@@ -231,7 +234,7 @@ No modules.
 | <a name="input_text_field"></a> [text\_field](#input\_text\_field) | The name of the field in which Amazon Bedrock stores the raw text from your data. | `string` | `"AMAZON_BEDROCK_TEXT_CHUNK"` | no |
 | <a name="input_top_k"></a> [top\_k](#input\_top\_k) | Sample from the k most likely next tokens. | `number` | `50` | no |
 | <a name="input_top_p"></a> [top\_p](#input\_top\_p) | Cumulative probability cutoff for token selection. | `number` | `0.5` | no |
-| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list( object({<br>                  name       = string<br>                  examples   = list(string)<br>                  type       = string<br>                  definition = string<br>                }))</pre> | `null` | no |
+| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list(object({<br/>    name       = string<br/>    examples   = list(string)<br/>    type       = string<br/>    definition = string<br/>  }))</pre> | `null` | no |
 | <a name="input_vector_field"></a> [vector\_field](#input\_vector\_field) | The name of the field where the vector embeddings are stored | `string` | `"bedrock-knowledge-base-default-vector"` | no |
 | <a name="input_vector_index_name"></a> [vector\_index\_name](#input\_vector\_index\_name) | The name of the vector index. | `string` | `"bedrock-knowledge-base-default-index"` | no |
 | <a name="input_words_config"></a> [words\_config](#input\_words\_config) | List of custom word configs. | `list(map(string))` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ No modules.
 | <a name="input_text_field"></a> [text\_field](#input\_text\_field) | The name of the field in which Amazon Bedrock stores the raw text from your data. | `string` | `"AMAZON_BEDROCK_TEXT_CHUNK"` | no |
 | <a name="input_top_k"></a> [top\_k](#input\_top\_k) | Sample from the k most likely next tokens. | `number` | `50` | no |
 | <a name="input_top_p"></a> [top\_p](#input\_top\_p) | Cumulative probability cutoff for token selection. | `number` | `0.5` | no |
-| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list(object({<br/>    name       = string<br/>    examples   = list(string)<br/>    type       = string<br/>    definition = string<br/>  }))</pre> | `null` | no |
+| <a name="input_topics_config"></a> [topics\_config](#input\_topics\_config) | List of topic configs in topic policy | <pre>list(object({<br>    name       = string<br>    examples   = list(string)<br>    type       = string<br>    definition = string<br>  }))</pre> | `null` | no |
 | <a name="input_vector_field"></a> [vector\_field](#input\_vector\_field) | The name of the field where the vector embeddings are stored | `string` | `"bedrock-knowledge-base-default-vector"` | no |
 | <a name="input_vector_index_name"></a> [vector\_index\_name](#input\_vector\_index\_name) | The name of the vector index. | `string` | `"bedrock-knowledge-base-default-index"` | no |
 | <a name="input_words_config"></a> [words\_config](#input\_words\_config) | List of custom word configs. | `list(map(string))` | `null` | no |

--- a/knowledge-base.tf
+++ b/knowledge-base.tf
@@ -157,6 +157,23 @@ resource "awscc_s3_bucket" "s3_data_source" {
   count       = var.kb_s3_data_source == null && var.create_default_kb == true ? 1 : 0
   bucket_name = "${random_string.solution_prefix.result}-${var.kb_name}-default-bucket"
 
+  public_access_block_configuration = {
+    block_public_acls       = true
+    block_public_policy     = true
+    ignore_public_acls      = true
+    restrict_public_buckets = true
+  }
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [{
+      bucket_key_enabled = true
+      server_side_encryption_by_default = {
+        sse_algorithm     = var.kb_s3_data_source_kms_arn == null ? "AES256" : "aws:kms"
+        kms_master_key_id = var.kb_s3_data_source_kms_arn
+      }
+    }]
+  }
+
   tags = [{
     key   = "Name"
     value = "S3 Data Source"

--- a/main.tf
+++ b/main.tf
@@ -104,16 +104,16 @@ resource "awscc_bedrock_guardrail" "guardrail" {
   }
   sensitive_information_policy_config = {
     pii_entities_config = var.pii_entities_config
-    regexes_config = var.regexes_config
+    regexes_config      = var.regexes_config
   }
   word_policy_config = {
     managed_word_lists_config = var.managed_word_lists_config
-    words_config = var.words_config
+    words_config              = var.words_config
   }
   topic_policy_config = var.topics_config == null ? null : {
     topics_config = var.topics_config
   }
-  tags = var.guardrail_tags
+  tags        = var.guardrail_tags
   kms_key_arn = var.guardrail_kms_key_arn
 
 }

--- a/opensearch.tf
+++ b/opensearch.tf
@@ -110,7 +110,7 @@ resource "opensearch_index" "default_oss_index" {
   number_of_replicas             = "0"
   index_knn                      = true
   index_knn_algo_param_ef_search = "512"
-    mappings                       = <<-EOF
+  mappings                       = <<-EOF
     {
       "properties": {
         "bedrock-knowledge-base-default-vector": {

--- a/variables.tf
+++ b/variables.tf
@@ -242,13 +242,13 @@ variable "words_config" {
 
 variable "topics_config" {
   description = "List of topic configs in topic policy"
-  type        = list( object({
-                  name       = string
-                  examples   = list(string)
-                  type       = string
-                  definition = string
-                }))
-  default     = null
+  type = list(object({
+    name       = string
+    examples   = list(string)
+    type       = string
+    definition = string
+  }))
+  default = null
 }
 
 variable "guardrail_tags" {
@@ -286,6 +286,12 @@ variable "create_default_kb" {
 
 variable "kb_s3_data_source" {
   description = "The S3 data source ARN for the knowledge base."
+  type        = string
+  default     = null
+}
+
+variable "kb_s3_data_source_kms_arn" {
+  description = "The ARN of the KMS key used to encrypt S3 content"
   type        = string
   default     = null
 }


### PR DESCRIPTION
This PR allows users to provide a KMS key to encrypt data at rest in S3. More importantly, the IAM role for the KB is granted decrypt access to the key for the purposes of ingesting content. The IAM permissions present in this PR match the specific policy generated by the AWS Console wizard for KB creation.

(This is a duplicate of PR 27 which was closed due to pre-commit difficulties)