### PR TITLE
fix: do not create the s3 data source

### DIFF
--- a/examples/agent-with-guardrails/main.tf
+++ b/examples/agent-with-guardrails/main.tf
@@ -9,6 +9,7 @@ module "bedrock" {
   create_kb = false
   create_default_kb = false
   create_guardrail = true
+  create_s3_data_source = false
   filters_config = [
       {
         input_strength  = "MEDIUM"


### PR DESCRIPTION
The default for `create_s3_data_source` is `true`, so set this to `false` for the example.