### PR TITLE
Fix data source: check if `semantic_max_tokens` is null

### DIFF
--- a/data-source.tf
+++ b/data-source.tf
@@ -13,7 +13,7 @@ locals {
         level_configurations = var.level_configurations_list
         overlap_tokens = var.heirarchical_overlap_tokens
       }
-      semantic_chunking_configuration = var.breakpoint_percentile_threshold == null && var.semantic_buffer_size == null && var.semantic_max_tokens ? null : {
+      semantic_chunking_configuration = var.breakpoint_percentile_threshold == null && var.semantic_buffer_size == null && var.semantic_max_tokens == null ? null : {
         breakpoint_percentile_threshold = var.breakpoint_percentile_threshold
         buffer_size = var.semantic_buffer_size
         max_tokens = var.semantic_max_tokens 


### PR DESCRIPTION
I have the following configuration:

```terraform
module "bedrock" {
  source  = "aws-ia/bedrock/aws"
  version = "0.0.8"
  create_default_kb = true
  create_s3_data_source = true
  foundation_model = "anthropic.claude-v2"
  instruction = "Some instruction"
  chunking_strategy = "FIXED_SIZE"
  chunking_strategy_max_tokens = 1000
  chunking_strategy_overlap_percentage = 20
}
```

It fails with the following error:

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid operand
│ 
│   on .terraform/modules/bedrock/data-source.tf line 16, in locals:
│   16:       semantic_chunking_configuration = var.breakpoint_percentile_threshold == null && var.semantic_buffer_size == null && var.semantic_max_tokens ? null : {
│     ├────────────────
│     │ var.semantic_max_tokens is null
│ 
│ Unsuitable value for right operand: bool required.
╵
```