### PR TITLE
Add Support for Permission Boundary on IAM Roles Created by Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="input_parsing_prompt_text"></a> [parsing\_prompt\_text](#input\_parsing\_prompt\_text) | Instructions for interpreting the contents of a document. | `string` | `null` | no |
 | <a name="input_parsing_strategy"></a> [parsing\_strategy](#input\_parsing\_strategy) | The parsing strategy for the data source. | `string` | `null` | no |
 | <a name="input_pattern_object_filter_list"></a> [pattern\_object\_filter\_list](#input\_pattern\_object\_filter\_list) | List of pattern object information. | <pre>list(object({<br>    exclusion_filters = optional(list(string))<br>    inclusion_filters = optional(list(string))<br>    object_type       = optional(string)<br><br>  }))</pre> | `[]` | no |
+| <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | The ARN of the IAM permission boundary for the role. | `string` | `null` | no |
 | <a name="input_pii_entities_config"></a> [pii\_entities\_config](#input\_pii\_entities\_config) | List of entities. | `list(map(string))` | `null` | no |
 | <a name="input_primary_key_field"></a> [primary\_key\_field](#input\_primary\_key\_field) | The name of the field in which Bedrock stores the ID for each entry. | `string` | `null` | no |
 | <a name="input_prompt_creation_mode"></a> [prompt\_creation\_mode](#input\_prompt\_creation\_mode) | Specifies whether to override the default prompt template. | `string` | `null` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -8,9 +8,10 @@ locals {
 
 
 resource "aws_iam_role" "agent_role" {
-  count              = var.create_agent || var.create_supervisor ? 1 : 0
-  assume_role_policy = data.aws_iam_policy_document.agent_trust[0].json
-  name_prefix        = var.name_prefix
+  count                 = var.create_agent || var.create_supervisor ? 1 : 0
+  assume_role_policy    = data.aws_iam_policy_document.agent_trust[0].json
+  name_prefix           = var.name_prefix
+  permissions_boundary  = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "agent_policy" {
@@ -48,6 +49,7 @@ resource "aws_iam_role" "bedrock_knowledge_base_role" {
       }
     ]
   })
+  permissions_boundary  = var.permissions_boundary_arn
 }
 
 # Attach a policy to allow necessary permissions for the Bedrock Knowledge Base
@@ -270,6 +272,7 @@ resource "aws_iam_role" "application_inference_profile_role" {
       }
     ]
   })
+  permissions_boundary  = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "app_inference_profile_policy" {
@@ -314,6 +317,7 @@ resource "aws_iam_role_policy" "app_inference_profile_policy" {
 resource "aws_iam_role" "custom_model_role" {
   count              = var.create_custom_model ? 1 : 0
   assume_role_policy = data.aws_iam_policy_document.custom_model_trust[0].json
+  permissions_boundary  = var.permissions_boundary_arn
   name_prefix        = "CustomModelRole"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1706,3 +1706,10 @@ variable "blueprint_tags" {
   }))
   default     = null
 }
+
+# - IAM -
+variable "permissions_boundary_arn" {
+  description = "The ARN of the IAM permission boundary for the role."
+  type        = string
+  default     = null  
+}


### PR DESCRIPTION
### Summary
This PR adds support for specifying a permissions boundary on the IAM roles created by the module.

### Motivation
In our enterprise environment, the Cloud Security team enforces IAM policies that require all roles to have a permissions boundary attached. Without this, module usage is blocked due to account-level restrictions. This change enables broader adoption of the module in security-restricted environments.

### Changes

- Introduced a new optional input variable: permissions_boundary_arn
- Updated IAM role creation logic to attach the specified permissions boundary if provided
- Preserved existing behavior for users who do not set this value (i.e., it remains optional and non-breaking)

### Example Usage
```
permissions_boundary_arn = "arn:aws:iam::123456789012:policy/MyPermissionsBoundary"
# ... other config
```

### Notes
This change is backwards compatible and does not impact existing deployments that do not require a permissions boundary.

We’ve tested this in our environment with enforced boundaries and confirmed it resolves the deployment issues.

Let us know if any changes are needed — happy to iterate on the implementation if there’s a preferred pattern you'd like us to follow.

Thanks!