### PR TITLE
Add Missing OpenSearch Terraform Provider to Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~>5.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 1.0.0 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | = 2.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 

--- a/providers.tf
+++ b/providers.tf
@@ -18,13 +18,8 @@ terraform {
       version = ">= 3.6.0"
     }
     opensearch = {
-      source = "opensearch-project/opensearch"
-      version = "~>2.0"
+      source  = "opensearch-project/opensearch"
+      version = "= 2.2.0"
     }
   }
-}
-
-provider "opensearch" {
-  url = "http://127.0.0.1:9200"
-  healthcheck = false
 }

--- a/providers.tf
+++ b/providers.tf
@@ -17,5 +17,14 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.6.0"
     }
+    opensearch = {
+      source = "opensearch-project/opensearch"
+      version = "~>2.0"
+    }
   }
+}
+
+provider "opensearch" {
+  url = "http://127.0.0.1:9200"
+  healthcheck = false
 }


### PR DESCRIPTION
### Summary
This PR adds the missing OpenSearch Terraform provider definition to the module.

### Motivation
The module references OpenSearch resources, but does not currently declare the required provider. This can lead to errors during Terraform plan/apply in environments where the OpenSearch provider is not already defined in the root configuration.

Adding the provider ensures that module consumers can use the module independently, without having to manually configure the OpenSearch provider in their own code.

### Changes
Added the opensearch provider block to providers.tf 

Included minimal configuration for version constraints, url and disabled health check.

### Example Provider Block
```
provider "opensearch" {
  url = "http://127.0.0.1:9200"
  healthcheck = false
}

terraform {
  required_providers {
    opensearch = {
      source  = "opensearch-project/opensearch"
      version = "~> 2.0"
    }
  }
}
```
### Notes
This change ensures smoother usage and better portability of the module.

If consumers need to customize the provider (e.g., custom endpoints or auth), they can still override it in their root config using provider aliases or overrides.

Please let me know if you'd like any adjustments.

Thanks!

