### PR TITLE
Expose the name of the S3 data source bucket as an output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,5 +876,6 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="output_pinecone_kb_identifier"></a> [pinecone\_kb\_identifier](#output\_pinecone\_kb\_identifier) | The unique identifier of the Pinecone knowledge base that was created.  If no Pinecone KB was requested, value will be null |
 | <a name="output_rds_kb_identifier"></a> [rds\_kb\_identifier](#output\_rds\_kb\_identifier) | The unique identifier of the RDS knowledge base that was created.  If no RDS KB was requested, value will be null |
 | <a name="output_s3_data_source_arn"></a> [s3\_data\_source\_arn](#output\_s3\_data\_source\_arn) | The Amazon Bedrock Data Source for S3. |
+| <a name="output_s3_data_source_name"></a> [s3\_data\_source\_name](#output\_s3\_data\_source\_name) | The name of the Amazon Bedrock Data Source for S3. |
 | <a name="output_supervisor_id"></a> [supervisor\_id](#output\_supervisor\_id) | The identifier of the supervisor agent. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "s3_data_source_arn" {
   description = "The Amazon Bedrock Data Source for S3."
 }
 
+output "s3_data_source_name" {
+  value       = var.kb_s3_data_source != null ? split("/", var.kb_s3_data_source)[1] : var.create_default_kb ? length(awscc_s3_bucket.s3_data_source) > 0 ? awscc_s3_bucket.s3_data_source[0].name : null : null
+  description = "The name of the Amazon Bedrock Data Source for S3."
+}
+
 output "supervisor_id" {
   value       = var.create_supervisor ? aws_bedrockagent_agent.agent_supervisor[0].agent_id : null
   description = "The identifier of the supervisor agent."

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,7 +49,7 @@ output "s3_data_source_arn" {
 }
 
 output "s3_data_source_name" {
-  value       = var.kb_s3_data_source != null ? split("/", var.kb_s3_data_source)[1] : var.create_default_kb ? length(awscc_s3_bucket.s3_data_source) > 0 ? awscc_s3_bucket.s3_data_source[0].name : null : null
+  value       = var.kb_s3_data_source != null ? split("/", var.kb_s3_data_source)[1] : var.create_default_kb ? length(awscc_s3_bucket.s3_data_source) > 0 ? awscc_s3_bucket.s3_data_source[0].id : null : null
   description = "The name of the Amazon Bedrock Data Source for S3."
 }
 


### PR DESCRIPTION
### Summary

Adds the bucket name for the S3 data source as an output. Presently only the ARN is exposed, so users of the module who need the bucket name (i.e., to fill in an environment variable for a Lambda that needs to know how to find it) have to parse it out of the ARN. This alleviates that.