### PR TITLE
Fix: Prevent IAM Policy Attachments When Using Existing Agent Role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -8,26 +8,27 @@ locals {
 }
 
 resource "aws_iam_role" "agent_role" {
-  count = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
+  # count = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
+  count = 0
   assume_role_policy    = data.aws_iam_policy_document.agent_trust[0].json
   name_prefix           = var.name_prefix
   permissions_boundary  = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "agent_policy" {
-  count  = var.create_agent ? 1 : 0
+  count  = var.agent_resource_role_arn == null && var.create_agent ? 1 : 0
   policy = data.aws_iam_policy_document.agent_permissions[0].json
   role   = local.agent_role_name
 }
 
 resource "aws_iam_role_policy" "agent_alias_policy" {
-  count  = var.create_agent_alias || var.create_supervisor ? 1 : 0
+  count  = var.agent_resource_role_arn == null && (var.create_agent_alias || var.create_supervisor) ? 1 : 0
   policy = data.aws_iam_policy_document.agent_alias_permissions[0].json
   role   = local.agent_role_name
 }
 
 resource "aws_iam_role_policy" "kb_policy" {
-  count  = local.create_kb && var.create_agent ? 1 : 0
+  count  = var.agent_resource_role_arn == null && local.create_kb && var.create_agent ? 1 : 0
   policy = data.aws_iam_policy_document.knowledge_base_permissions[0].json
   role   = local.agent_role_name
 }

--- a/iam.tf
+++ b/iam.tf
@@ -8,8 +8,7 @@ locals {
 }
 
 resource "aws_iam_role" "agent_role" {
-  # count = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
-  count = 0
+  count = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
   assume_role_policy    = data.aws_iam_policy_document.agent_trust[0].json
   name_prefix           = var.name_prefix
   permissions_boundary  = var.permissions_boundary_arn


### PR DESCRIPTION
### Summary
This PR fixes an issue where the module attempts to attach IAM policies to an existing IAM role passed to the Bedrock Agent during creation, causing deployment failures in environments without IAM permissions.

### Problem
When no IAM role is provided, the module correctly creates a new role and attaches the necessary policies. However, when a user provides an existing IAM role (via the appropriate variable), the module still attempts to attach the auto-generated IAM policies to that role.

This creates a critical issue in environments — such as ours — where IAM permissions are restricted (i.e., we can reference existing IAM roles but not modify them or attach policies). As a result, the deployment fails due to insufficient permissions.

### Solution
This PR updates the logic to detect when an existing IAM role is provided and skips all IAM policy attachment steps in that case.

### Changes

- Introduced a conditional check to detect usage of an existing agent IAM role
- Skipped IAM policy attachments when an existing role is used
- Preserved existing behavior for users who do not provide a custom role (i.e., the module will still create and attach policies as before)

**Example Scenario**

```hcl
Copy
Edit
module "bedrock_agent" {
  source = "..."

  agent_role_arn = "arn:aws:iam::123456789012:role/PreExistingAgentRole"

  # ... other configuration
}
```

In the above configuration:

- No IAM policy attachments will be attempted
- The provided role will be used as-is, avoiding permission-related deployment failures

### Notes

- This change is backward-compatible and safe for users who are not using an existing role
- Supports secure deployments in IAM-restricted enterprise environments

Let me know if there are other edge cases or related logic you'd like to see reviewed or refactored along with this change.

Thanks!