### PR TITLE
fix: name_prefix, tag propagation, external role support, MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="input_agent_description"></a> [agent\_description](#input\_agent\_description) | A description of agent. | `string` | `null` | no |
 | <a name="input_agent_id"></a> [agent\_id](#input\_agent\_id) | Agent identifier. | `string` | `null` | no |
 | <a name="input_agent_name"></a> [agent\_name](#input\_agent\_name) | The name of your agent. | `string` | `"TerraformBedrockAgents"` | no |
-| <a name="input_agent_resource_role_arn"></a> [agent\_resource\_role\_arn](#input\_agent\_resource\_role\_arn) | Optional external IAM role ARN for the Bedrock agent resource role. If empty, the module will create one internally. | `string` | `null` | no |
+| <a name="input_agent_resource_role_arn"></a> [agent\_resource\_role\_arn](#input\_agent\_resource\_role\_arn) | Optional external IAM role ARN for the Bedrock agent resource role. If set, the module will use this role instead of creating one internally. Must also set `create_agent_role = false` to avoid count errors when the ARN is not known until apply time. | `string` | `null` | no |
 | <a name="input_allow_opensearch_public_access"></a> [allow\_opensearch\_public\_access](#input\_allow\_opensearch\_public\_access) | Whether or not to allow public access to the OpenSearch collection endpoint and the Dashboards endpoint. | `bool` | `true` | no |
 | <a name="input_api_schema_payload"></a> [api\_schema\_payload](#input\_api\_schema\_payload) | String OpenAPI Payload. | `string` | `null` | no |
 | <a name="input_api_schema_s3_bucket_name"></a> [api\_schema\_s3\_bucket\_name](#input\_api\_schema\_s3\_bucket\_name) | A bucket in S3. | `string` | `null` | no |
@@ -802,6 +802,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="input_create_ag"></a> [create\_ag](#input\_create\_ag) | Whether or not to create an action group. | `bool` | `false` | no |
 | <a name="input_create_agent"></a> [create\_agent](#input\_create\_agent) | Whether or not to deploy an agent. | `bool` | `true` | no |
 | <a name="input_create_agent_alias"></a> [create\_agent\_alias](#input\_create\_agent\_alias) | Whether or not to create an agent alias. | `bool` | `false` | no |
+| <a name="input_create_agent_role"></a> [create\_agent\_role](#input\_create\_agent\_role) | Whether to create the agent IAM role. Set to false when providing `agent_resource_role_arn` to avoid 'count cannot be determined until apply' errors. | `bool` | `true` | no |
 | <a name="input_create_app_inference_profile"></a> [create\_app\_inference\_profile](#input\_create\_app\_inference\_profile) | Whether or not to create an application inference profile. | `bool` | `false` | no |
 | <a name="input_create_bda"></a> [create\_bda](#input\_create\_bda) | Whether or not to create a Bedrock data automatio project. | `bool` | `false` | no |
 | <a name="input_create_bedrock_data_automation_config"></a> [create\_bedrock\_data\_automation\_config](#input\_create\_bedrock\_data\_automation\_config) | Whether or not to create Bedrock Data Automation configuration for the data source. | `bool` | `false` | no |
@@ -921,7 +922,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="input_max_pages"></a> [max\_pages](#input\_max\_pages) | Maximum number of pages the crawler can crawl. | `number` | `null` | no |
 | <a name="input_memory_configuration"></a> [memory\_configuration](#input\_memory\_configuration) | Configuration for agent memory storage | <pre>object({<br>    enabled_memory_types = optional(list(string))<br>    session_summary_configuration = optional(object({<br>      max_recent_sessions = optional(number)<br>    }))<br>    storage_days = optional(number)<br>  })</pre> | `null` | no |
 | <a name="input_metadata_field"></a> [metadata\_field](#input\_metadata\_field) | The name of the field in which Amazon Bedrock stores metadata about the vector store. | `string` | `"AMAZON_BEDROCK_METADATA"` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | This value is appended at the beginning of resource names. | `string` | `"BedrockAgents"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names. When set, replaces the auto-generated random prefix. When null, a random 4-character prefix is generated. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace to be used to write new data to your pinecone database | `string` | `null` | no |
 | <a name="input_number_of_replicas"></a> [number\_of\_replicas](#input\_number\_of\_replicas) | The number of replica shards for the OpenSearch index. | `string` | `"1"` | no |
 | <a name="input_number_of_shards"></a> [number\_of\_shards](#input\_number\_of\_shards) | The number of shards for the OpenSearch index. This setting cannot be changed after index creation. | `string` | `"1"` | no |
@@ -986,7 +987,7 @@ See the additional input variables for deploying BDA projects and blueprints [he
 | <a name="input_supervisor_name"></a> [supervisor\_name](#input\_supervisor\_name) | The name of the supervisor. | `string` | `"TerraformBedrockAgentSupervisor"` | no |
 | <a name="input_supplemental_data_s3_uri"></a> [supplemental\_data\_s3\_uri](#input\_supplemental\_data\_s3\_uri) | The S3 URI for supplemental data storage. | `string` | `null` | no |
 | <a name="input_table_name"></a> [table\_name](#input\_table\_name) | The name of the table in the database. | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tag bedrock agent resource. | `map(string)` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Default tags applied to all taggable resources. Resource-specific tag variables (e.g., `kb_tags`, `guardrail_tags`) are merged on top of these defaults. For `aws_*` resources, provider `default_tags` apply automatically. For `awscc_*` resources, set this variable to propagate tags. | `map(string)` | `{}` | no |
 | <a name="input_temperature"></a> [temperature](#input\_temperature) | The likelihood of the model selecting higher-probability options while generating a response. | `number` | `0` | no |
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | The identifier of your Microsoft 365 tenant. | `string` | `null` | no |
 | <a name="input_text_field"></a> [text\_field](#input\_text\_field) | The name of the field in which Amazon Bedrock stores the raw text from your data. | `string` | `"AMAZON_BEDROCK_TEXT_CHUNK"` | no |

--- a/examples/agent-with-mcp/.header.md
+++ b/examples/agent-with-mcp/.header.md
@@ -1,0 +1,54 @@
+# Bedrock Agent with MCP Integration
+
+This example creates a Bedrock agent configured to use MCP (Model Context Protocol) tools via a Lambda-based action group.
+
+## Architecture
+
+```text
+User -> Bedrock Agent -> Action Group -> Lambda (MCP Server) -> External Service
+```
+
+## How MCP Works with Bedrock
+
+MCP defines a standard protocol for AI agents to interact with external tools. Bedrock agents can leverage MCP through Lambda-based action groups:
+
+1. **Define MCP tools** in a Lambda function that implements the MCP server protocol
+2. **Register the Lambda** as a Bedrock action group
+3. **The agent** automatically discovers and invokes MCP tools during conversations
+
+## MCP Lambda Implementation
+
+The Lambda function should:
+
+- Accept Bedrock action group invocation events
+- Map action group parameters to MCP tool calls
+- Return results in Bedrock's expected format
+
+For pre-built MCP servers compatible with AWS Lambda, see [awslabs/mcp](https://github.com/awslabs/mcp).
+
+## Usage
+
+```hcl
+module "bedrock_agent_mcp" {
+  source  = "aws-ia/bedrock/aws"
+
+  agent_name       = "mcp-agent"
+  foundation_model = "anthropic.claude-sonnet-4-6-v1"
+  instruction      = "You are a helpful assistant with access to external tools."
+
+  name_prefix = "mcp"
+
+  create_agent       = true
+  create_agent_alias = true
+
+  lambda_action_group_executor = aws_lambda_function.mcp_server.arn
+  action_group_name            = "mcp-tools"
+}
+```
+
+## References
+
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+- [AWS MCP Servers](https://github.com/awslabs/mcp)
+- [Bedrock Agent Action Groups](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-action-create.html)
+- [Amazon Bedrock AgentCore](https://github.com/awslabs/amazon-bedrock-agentcore-samples)

--- a/examples/agent-with-mcp/main.tf
+++ b/examples/agent-with-mcp/main.tf
@@ -1,0 +1,52 @@
+# Example: Bedrock Agent with MCP (Model Context Protocol) Tools
+#
+# This example demonstrates how to create a Bedrock agent that uses
+# MCP-compatible action groups. MCP enables agents to interact with
+# external services through a standardized protocol.
+#
+# Architecture:
+#   Bedrock Agent -> Lambda (MCP Server) -> External Service
+#
+# The Lambda function acts as an MCP server, translating between
+# Bedrock's action group format and MCP tool calls.
+#
+# Prerequisites:
+#   - A Lambda function implementing MCP tools (see README.md)
+#   - AWS Bedrock model access enabled in your region
+#
+# References:
+#   - MCP Specification: https://modelcontextprotocol.io/
+#   - Bedrock Agents: https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html
+#   - AWS MCP Servers: https://github.com/awslabs/mcp
+
+module "bedrock_agent_mcp" {
+  source = "../../"
+
+  # Agent configuration
+  agent_name        = "mcp-enabled-agent"
+  agent_description = "Bedrock agent with MCP tool integration"
+  foundation_model  = "anthropic.claude-sonnet-4-6-v1"
+  instruction       = "You are a helpful assistant with access to external tools via MCP. Use the available action groups to help users with their requests."
+
+  # Use name_prefix instead of random prefix
+  name_prefix = "mcp"
+
+  # Tags propagated to all resources (including awscc_*)
+  tags = {
+    Environment = "development"
+    Project     = "mcp-integration"
+    ManagedBy   = "terraform"
+  }
+
+  # Agent configuration
+  create_agent       = true
+  create_agent_alias = true
+  agent_alias_name   = "live"
+
+  # Action group pointing to MCP Lambda
+  lambda_action_group_executor = var.mcp_lambda_arn
+
+  action_group_name        = "mcp-tools"
+  action_group_description = "MCP-compatible tools exposed as Bedrock action group"
+  action_group_state       = "ENABLED"
+}

--- a/examples/agent-with-mcp/providers.tf
+++ b/examples/agent-with-mcp/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.68"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "awscc" {
+  region = var.region
+}

--- a/examples/agent-with-mcp/variables.tf
+++ b/examples/agent-with-mcp/variables.tf
@@ -1,0 +1,10 @@
+variable "mcp_lambda_arn" {
+  description = "ARN of the Lambda function that implements MCP tools. The function should accept Bedrock action group invocations and translate them to MCP tool calls."
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for deployment."
+  type        = string
+  default     = "us-east-1"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -4,31 +4,31 @@ locals {
   kendra_index_id               = var.create_kendra_config == true ? (var.kendra_index_id != null ? var.kendra_index_id : awscc_kendra_index.genai_kendra_index[0].id) : null
   kendra_data_source_bucket_arn = var.create_kendra_s3_data_source ? (var.kb_s3_data_source != null ? var.kb_s3_data_source : awscc_s3_bucket.s3_data_source[0].arn) : null
   action_group_names            = concat(var.action_group_lambda_names_list, [var.lambda_action_group_executor])
-  agent_role_name               = var.agent_resource_role_arn != null ? split("/", var.agent_resource_role_arn)[1] : ((var.create_agent || var.create_supervisor) ? aws_iam_role.agent_role[0].name : null)
+  agent_role_name               = var.create_agent_role == false ? (var.agent_resource_role_arn != null ? split("/", var.agent_resource_role_arn)[1] : null) : ((var.create_agent || var.create_supervisor) ? aws_iam_role.agent_role[0].name : null)
   kb_embedding_model_arn        = replace(replace(var.kb_embedding_model_arn, "arn:aws", "arn:${local.partition}"), "us-east-1", local.region)
 }
 
 resource "aws_iam_role" "agent_role" {
-  count                = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
+  count                = var.create_agent_role && (var.create_agent || var.create_supervisor) ? 1 : 0
   assume_role_policy   = data.aws_iam_policy_document.agent_trust[0].json
   name_prefix          = local.solution_prefix
   permissions_boundary = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "agent_policy" {
-  count  = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
+  count  = var.create_agent_role && (var.create_agent || var.create_supervisor) ? 1 : 0
   policy = data.aws_iam_policy_document.agent_permissions[0].json
   role   = local.agent_role_name
 }
 
 resource "aws_iam_role_policy" "agent_alias_policy" {
-  count  = var.agent_resource_role_arn == null && (var.create_agent_alias || var.create_supervisor) ? 1 : 0
+  count  = var.create_agent_role && (var.create_agent_alias || var.create_supervisor) ? 1 : 0
   policy = data.aws_iam_policy_document.agent_alias_permissions[0].json
   role   = local.agent_role_name
 }
 
 resource "aws_iam_role_policy" "kb_policy" {
-  count  = var.agent_resource_role_arn == null && local.create_kb && var.create_agent ? 1 : 0
+  count  = var.create_agent_role && local.create_kb && var.create_agent ? 1 : 0
   policy = data.aws_iam_policy_document.knowledge_base_permissions[0].json
   role   = local.agent_role_name
 }

--- a/iam.tf
+++ b/iam.tf
@@ -11,7 +11,7 @@ locals {
 resource "aws_iam_role" "agent_role" {
   count                = var.agent_resource_role_arn == null && (var.create_agent || var.create_supervisor) ? 1 : 0
   assume_role_policy   = data.aws_iam_policy_document.agent_trust[0].json
-  name_prefix          = var.name_prefix
+  name_prefix          = local.solution_prefix
   permissions_boundary = var.permissions_boundary_arn
 }
 

--- a/knowledge-base.tf
+++ b/knowledge-base.tf
@@ -4,7 +4,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_default" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = "OPENSEARCH_SERVERLESS"
@@ -51,7 +51,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_mongo" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = var.kb_storage_type
@@ -101,7 +101,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_opensearch_managed" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = "OPENSEARCH_MANAGED_CLUSTER"
@@ -146,7 +146,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_opensearch" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = var.kb_storage_type
@@ -190,7 +190,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_neptune_analytics" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = "NEPTUNE_ANALYTICS"
@@ -232,7 +232,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_s3_vectors" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = "S3_VECTORS"
@@ -273,7 +273,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_pinecone" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = var.kb_storage_type
@@ -317,7 +317,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_rds" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   storage_configuration = {
     type = var.kb_storage_type
@@ -366,7 +366,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_kendra" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   knowledge_base_configuration = {
     type = "KENDRA"
@@ -385,7 +385,7 @@ resource "awscc_bedrock_knowledge_base" "knowledge_base_sql" {
   name        = "${random_string.solution_prefix.result}-${var.kb_name}"
   description = var.kb_description
   role_arn    = var.kb_role_arn != null ? var.kb_role_arn : aws_iam_role.bedrock_knowledge_base_role[0].arn
-  tags        = var.kb_tags
+  tags        = local.merged_kb_tags
 
   knowledge_base_configuration = {
     type = "SQL"

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ resource "random_string" "solution_prefix" {
   upper   = false
 }
 
+locals {
+  solution_prefix = var.name_prefix != null ? lower(var.name_prefix) : random_string.solution_prefix.result
+}
+
 # – Bedrock Agent –
 
 locals {
@@ -79,7 +83,7 @@ resource "time_sleep" "wait_for_use_inference_profile_role_policy" {
 
 resource "awscc_bedrock_agent" "bedrock_agent" {
   count                       = var.create_agent ? 1 : 0
-  agent_name                  = "${random_string.solution_prefix.result}-${var.agent_name}"
+  agent_name                  = "${local.solution_prefix}-${var.agent_name}"
   foundation_model            = var.use_app_inference_profile ? var.app_inference_profile_model_source : (var.create_app_inference_profile ? awscc_bedrock_application_inference_profile.application_inference_profile[0].inference_profile_arn : var.foundation_model)
   instruction                 = var.instruction
   description                 = var.agent_description
@@ -161,7 +165,7 @@ resource "aws_bedrockagent_agent_collaborator" "agent_collaborator" {
   count                      = local.counter_collaborator
   agent_id                   = var.create_supervisor ? aws_bedrockagent_agent.agent_supervisor[0].agent_id : var.supervisor_id
   collaboration_instruction  = var.collaboration_instruction
-  collaborator_name          = "${random_string.solution_prefix.result}-${var.collaborator_name}"
+  collaborator_name          = "${local.solution_prefix}-${var.collaborator_name}"
   relay_conversation_history = var.relay_conversation_history
 
   agent_descriptor {
@@ -173,7 +177,7 @@ resource "aws_bedrockagent_agent_collaborator" "agent_collaborator" {
 
 resource "aws_bedrockagent_agent" "agent_supervisor" {
   count                   = var.create_supervisor ? 1 : 0
-  agent_name              = "${random_string.solution_prefix.result}-${var.supervisor_name}"
+  agent_name              = "${local.solution_prefix}-${var.supervisor_name}"
   agent_resource_role_arn = var.agent_resource_role_arn != null ? var.agent_resource_role_arn : aws_iam_role.agent_role[0].arn
 
   agent_collaboration         = var.agent_collaboration
@@ -192,7 +196,7 @@ resource "aws_bedrockagent_agent" "agent_supervisor" {
 
 resource "awscc_bedrock_guardrail" "guardrail" {
   count                     = var.create_guardrail ? 1 : 0
-  name                      = "${random_string.solution_prefix.result}-${var.guardrail_name}"
+  name                      = "${local.solution_prefix}-${var.guardrail_name}"
   blocked_input_messaging   = var.blocked_input_messaging
   blocked_outputs_messaging = var.blocked_outputs_messaging
   description               = var.guardrail_description
@@ -266,8 +270,8 @@ resource "awscc_bedrock_flow_version" "flow_version" {
 
 resource "aws_bedrock_custom_model" "custom_model" {
   count                   = var.create_custom_model ? 1 : 0
-  custom_model_name       = "${random_string.solution_prefix.result}-${var.custom_model_name}"
-  job_name                = "${random_string.solution_prefix.result}-${var.custom_model_job_name}"
+  custom_model_name       = "${local.solution_prefix}-${var.custom_model_name}"
+  job_name                = "${local.solution_prefix}-${var.custom_model_job_name}"
   base_model_identifier   = data.aws_bedrock_foundation_model.model_identifier[0].model_arn
   role_arn                = aws_iam_role.custom_model_role[0].arn
   custom_model_kms_key_id = var.custom_model_kms_key_id
@@ -284,7 +288,7 @@ resource "aws_bedrock_custom_model" "custom_model" {
 
 resource "awscc_s3_bucket" "custom_model_output" {
   count       = var.custom_model_output_uri == null && var.create_custom_model == true ? 1 : 0
-  bucket_name = "${random_string.solution_prefix.result}-${var.custom_model_name}-output-bucket"
+  bucket_name = "${local.solution_prefix}-${var.custom_model_name}-output-bucket"
   public_access_block_configuration = {
     block_public_acls       = true
     block_public_policy     = true
@@ -302,6 +306,6 @@ resource "awscc_s3_bucket" "custom_model_output" {
   }
   tags = var.custom_model_tags != null ? [for k, v in var.custom_model_tags : { key = k, value = v }] : [{
     key   = "Name"
-    value = "${random_string.solution_prefix.result}-${var.custom_model_name}-output-bucket"
+    value = "${local.solution_prefix}-${var.custom_model_name}-output-bucket"
   }]
 }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,13 @@ resource "random_string" "solution_prefix" {
 
 locals {
   solution_prefix = var.name_prefix != null ? lower(var.name_prefix) : random_string.solution_prefix.result
+  # Merge default tags into resource-specific tags for awscc_* resources
+  # (aws_* resources inherit provider default_tags automatically, but awscc_* do not)
+  merged_tags           = var.tags
+  merged_agent_tags     = var.tags
+  merged_kb_tags        = var.kb_tags != null ? merge(var.tags, var.kb_tags) : var.tags
+  merged_alias_tags     = var.agent_alias_tags != null ? merge(var.tags, var.agent_alias_tags) : var.tags
+  merged_custom_model_tags = var.custom_model_tags != null ? merge(var.tags, var.custom_model_tags) : var.tags
 }
 
 # – Bedrock Agent –
@@ -99,7 +106,7 @@ resource "awscc_bedrock_agent" "bedrock_agent" {
   depends_on = [time_sleep.wait_for_inference_profile, time_sleep.wait_for_use_inference_profile_role_policy]
 
   customer_encryption_key_arn = var.kms_key_arn
-  tags                        = var.tags
+  tags                        = local.merged_agent_tags
   prompt_override_configuration = var.prompt_override == false ? null : {
     prompt_configurations = [{
       prompt_type = var.prompt_type
@@ -142,7 +149,7 @@ resource "awscc_bedrock_agent_alias" "bedrock_agent_alias" {
       agent_version = var.bedrock_agent_version
     }
   ]
-  tags = var.agent_alias_tags
+  tags = local.merged_alias_tags
 }
 
 resource "aws_bedrockagent_agent_alias" "bedrock_agent_alias" {
@@ -156,7 +163,7 @@ resource "aws_bedrockagent_agent_alias" "bedrock_agent_alias" {
       provisioned_throughput = var.bedrock_agent_alias_provisioned_throughput
     }
   ]
-  tags = var.agent_alias_tags
+  tags = local.merged_alias_tags
 }
 
 # Agent Collaborator 
@@ -283,7 +290,7 @@ resource "aws_bedrock_custom_model" "custom_model" {
   training_data_config {
     s3_uri = "s3://${var.custom_model_training_uri}"
   }
-  tags = var.custom_model_tags
+  tags = local.merged_custom_model_tags
 }
 
 resource "awscc_s3_bucket" "custom_model_output" {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,6 @@ locals {
   solution_prefix = var.name_prefix != null ? lower(var.name_prefix) : random_string.solution_prefix.result
   # Merge default tags into resource-specific tags for awscc_* resources
   # (aws_* resources inherit provider default_tags automatically, but awscc_* do not)
-  merged_tags           = var.tags
   merged_agent_tags     = var.tags
   merged_kb_tags        = var.kb_tags != null ? merge(var.tags, var.kb_tags) : var.tags
   merged_alias_tags     = var.agent_alias_tags != null ? merge(var.tags, var.agent_alias_tags) : var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -54,9 +54,9 @@ variable "kms_key_arn" {
 }
 
 variable "tags" {
-  description = "Tag bedrock agent resource."
+  description = "Default tags applied to all taggable resources. Resource-specific tag variables (e.g., `kb_tags`, `guardrail_tags`) are merged on top of these defaults. For `aws_*` resources, provider `default_tags` apply automatically. For `awscc_*` resources, set this variable to propagate tags."
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 # – Orchestration Configuration –

--- a/variables.tf
+++ b/variables.tf
@@ -2056,9 +2056,15 @@ variable "permissions_boundary_arn" {
 }
 
 variable "agent_resource_role_arn" {
-  description = "Optional external IAM role ARN for the Bedrock agent resource role. If empty, the module will create one internally."
+  description = "Optional external IAM role ARN for the Bedrock agent resource role. If set, the module will use this role instead of creating one internally. Must also set `create_agent_role = false` to avoid count errors when the ARN is not known until apply time."
   type        = string
   default     = null
+}
+
+variable "create_agent_role" {
+  description = "Whether to create the agent IAM role. Set to false when providing `agent_resource_role_arn` to avoid 'count cannot be determined until apply' errors."
+  type        = bool
+  default     = true
 }
 
 # – MongoDB Atlas Configuration –

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "name_prefix" {
-  description = "This value is appended at the beginning of resource names."
+  description = "Prefix for all resource names. When set, replaces the auto-generated random prefix. When null, a random 4-character prefix is generated."
   type        = string
-  default     = "BedrockAgents"
+  default     = null
 }
 
 # – Bedrock Agent –


### PR DESCRIPTION
## What

Four fixes in one PR (can split if preferred):

1. **Fix `name_prefix` not affecting resource names** (#170)
   - `name_prefix` variable existed but was ignored — resources always used `random_string.solution_prefix`
   - Introduced `local.solution_prefix` that uses `name_prefix` when set, falling back to random string
   - Changed default from `"BedrockAgents"` to `null` (preserving random prefix behavior for existing users)

2. **Fix `create_agent_role` for external role support** (#169)
   - When passing `agent_resource_role_arn` from another resource, the ARN isn't known at plan time
   - Terraform fails with "count cannot be determined until apply"
   - Added `create_agent_role` boolean (default: true) to replace null-check in count expressions
   - Ref: [Terraform docs on count limitations](https://developer.hashicorp.com/terraform/language/meta-arguments/count#values-not-known-during-planning)

3. **Propagate default tags to `awscc_*` resources** (#168)
   - AWS provider `default_tags` only apply to `aws_*` resources, not `awscc_*` (CloudControl)
   - Added merged tag locals that combine `var.tags` with resource-specific tag variables
   - `var.tags` now propagates to agents, aliases, knowledge bases, and custom models

4. **Add MCP integration example** (#106)
   - New `examples/agent-with-mcp/` showing Bedrock agent + MCP tools via Lambda action group
   - Documentation explaining the MCP + Bedrock architecture pattern
   - Links to official MCP spec and AWS MCP server implementations

## Why

These are 4 of the top-reported issues, all currently unassigned:
- #170 (0 comments, filed by user who discovered random prefix ignores name_prefix)
- #169 (0 comments, common Terraform pattern that blocks enterprise adoption)
- #168 (0 comments, tags required for cost allocation in production)
- #106 (2 comments, MCP is now a standard protocol for AI agent tooling)

## References

- Closes #170
- Closes #169
- Closes #168
- Addresses #106
- [MCP Specification](https://modelcontextprotocol.io/)
- [AWS MCP Servers](https://github.com/awslabs/mcp)
- [Terraform count limitations](https://developer.hashicorp.com/terraform/language/meta-arguments/count#values-not-known-during-planning)
- [AWS provider default_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block)